### PR TITLE
fix javascript error which was disallowing code from being highlighted

### DIFF
--- a/rtsyntax.php
+++ b/rtsyntax.php
@@ -111,7 +111,13 @@ class rtSyntax {
     }
     
     public function onload() { ?>
-        <script>hljs.initHighlightingOnLoad();</script><?php
+        <script>
+            $( function() {
+                if( typeof hljs === 'object' ) {
+                    hljs.initHighlightingOnLoad();
+                }
+            } );
+        </script><?php
     }
     
     public function convert_pres( $content ){


### PR DESCRIPTION
As highlight.js is included in footer and hljs.initHighlightingOnLoad(); is loaded in header it throws javascript error which disallows code from being highlighted. This commit invokes initHighlightingOnLoad function on document ready to avoid script failure.